### PR TITLE
修复多个点的文件按类型匹配的问题

### DIFF
--- a/src/Swoole/ToolKit/AutoReload.php
+++ b/src/Swoole/ToolKit/AutoReload.php
@@ -67,7 +67,7 @@ class AutoReload
                 }
                 else if ($ev['mask'] == IN_CREATE or $ev['mask'] == IN_DELETE or $ev['mask'] == IN_MODIFY or $ev['mask'] == IN_MOVED_TO or $ev['mask'] == IN_MOVED_FROM)
                 {
-                    $fileType = strstr($ev['name'], '.');
+                    $fileType = strrchr($ev['name'], '.');
                     //非重启类型
                     if (!isset($this->reloadFileTypes[$fileType]))
                     {
@@ -174,7 +174,7 @@ class AutoReload
                 $this->watch($path, false);
             }
             //检测文件类型
-            $fileType = strstr($f, '.');
+            $fileType = strrchr($f, '.');
             if (isset($this->reloadFileTypes[$fileType]))
             {
                 $wd = inotify_add_watch($this->inotify, $path, $this->events);


### PR DESCRIPTION
目前取文件后缀名用的 `strstr`，会导致 `a.class.php` 不认为是 php 文件的情况。
将函数改为 `strrchr` 获取最后一个 `.` 之后的文本作为文件后缀名，这样 `.php` 就可以匹配类似 `.inc.php` 、 `.class.php` 之类的文件。